### PR TITLE
Potential fix for code scanning alert no. 2: Missing CSRF middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,8 @@
     "connect-pg-simple": "^9.0.1",
     "openid-client": "^5.7.1",
     "passport": "^0.7.0",
-    "passport-openidconnect": "^0.1.2"
+    "passport-openidconnect": "^0.1.2",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ const session = require('express-session');
 const pgSession = require('connect-pg-simple')(session);
 const passport = require('passport');
 const path = require('path');
+const csrf = require('lusca').csrf;
 require('dotenv').config();
 
 const { pool } = require('./config/database');
@@ -93,6 +94,9 @@ app.use(session({
     maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
   }
 }));
+
+// CSRF Protection middleware
+app.use(csrf());
 
 // Initialize Passport
 app.use(passport.initialize());


### PR DESCRIPTION
Potential fix for [https://github.com/syl3n7/ipmaia-winterjam/security/code-scanning/2](https://github.com/syl3n7/ipmaia-winterjam/security/code-scanning/2)

To fix the missing CSRF protection, you should add a CSRF middleware right after cookies and session middleware are set up, before any state-changing or sensitive route handlers. The recommended and widely used library for Express apps is `lusca`, which provides a simple CSRF middleware compatible with session and cookie parsers.  

**Implementation steps:**
- Install `lusca` as a dependency in your project (see Dependencies section).
- Import the `csrf` middleware from `lusca`.
- Add `app.use(csrf())` after `cookieParser` and `session` middleware, and before routing.
- If your frontend needs to access the emitted CSRF token (for AJAX requests, etc.), you may also want to inject it into responses, for example using a middleware to set it as a cookie or in a response header where relevant. (This step is OPTIONAL for base CSRF protection, but may be required by your frontend.)

In summary:  
- Imports: Import `csrf` from `lusca`.  
- Place: After cookieParser and session middleware (after line 95), add `app.use(csrf())`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
